### PR TITLE
Cluster id and namespace selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Action for Github to deploy image in Rancher using Rancher API
+# Action for GitHub to re deploy image in Rancher using Rancher API
+
+This action redeploys existing service. It's handy for automated pipeline which is building app, creating container
+image and when that updated container image is needed to be deployed.
 
 ## Environment variables
 
@@ -6,6 +9,8 @@
 RANCHER_ACCESS_KEY=
 RANCHER_SECRET_KEY=
 RANCHER_URL_API=https://<address>/v3
+RANCHER_CLUSTER_ID=
+NAMESPACE_ID=
 SERVICE_NAME=
 DOCKER_IMAGE=
 DOCKER_IMAGE_LATEST=
@@ -14,13 +19,17 @@ DOCKER_IMAGE_LATEST=
 `RANCHER_ACCESS_KEY` **Required** API Access key created in Rancher.  
 `RANCHER_SECRET_KEY` **Required** API Secret key created in Rancher.  
 `RANCHER_URL_API` **Required** API url of your rancher. Example https://server-address/v3.  
+`RANCHER_CLUSTER_ID` **Required** Cluster id can be found from url
+like `https://server-address/v3/dashboard/c/c-m-dsmw2q28/explorer#cluster-events` here cluster id is `c-m-dsmw2q28`
+part.   
+`NAMESPACE_ID` **Required** deploy action uses selected namespace id  
 `SERVICE_NAME` **Required** Name of your service on Rancher cluster which you want deploy/redeploy.  
 `DOCKER_IMAGE` **Required** URL of your docker image.    
 `DOCKER_IMAGE_LATEST` **Optional** URL of your docker image including latest tag.
 
 ## Example usage
 
-Example for github actions workflow
+Example for GitHub actions workflow
 
 ```yaml
 - name: Rancher Deploy
@@ -29,6 +38,8 @@ Example for github actions workflow
     RANCHER_ACCESS_KEY: ${{ secrets.RANCHER_ACCESS_KEY }}
     RANCHER_SECRET_KEY: ${{ secrets.RANCHER_SECRET_KEY }}
     RANCHER_URL_API: ${{ secrets.RANCHER_URL_API }}
+    RANCHER_CLUSTER_ID: ${{ secrets.RANCHER_CLUSTER_ID }}
+    NAMESPACE_ID: ${{ secrets.NAMESPACE_ID }}
     SERVICE_NAME: 'service-name'
     DOCKER_IMAGE: 'ghcr.io/xxxxxxx'
     DOCKER_IMAGE_LATEST: 'ghcr.io/xxxxxxx:latest'

--- a/deploy_to_rancher.py
+++ b/deploy_to_rancher.py
@@ -5,12 +5,20 @@ import requests
 
 class DeployRancher:
     def __init__(
-            self, rancher_access_key, rancher_secret_key, rancher_url_api,
-            rancher_service_name, rancher_docker_image
+            self,
+            rancher_access_key,
+            rancher_secret_key,
+            rancher_url_api,
+            rancher_cluster_id,
+            rancher_namespace_id,
+            rancher_service_name,
+            rancher_docker_image
     ):
         self.access_key = rancher_access_key
         self.secret_key = rancher_secret_key
         self.rancher_url_api = rancher_url_api
+        self.rancher_cluster_id = rancher_cluster_id
+        self.rancher_namespace_id = rancher_namespace_id
         self.service_name = rancher_service_name
         self.docker_image = rancher_docker_image
         self.rancher_deployment_path = ''
@@ -21,6 +29,7 @@ class DeployRancher:
         rp = requests.get('{}/projects'.format(self.rancher_url_api), auth=(self.access_key, self.secret_key))
         projects = rp.json()
         for p in projects['data']:
+            print(p)
             w_url = '{}/projects/{}/workloads'.format(self.rancher_url_api, p['id'])
             rw = requests.get(w_url, auth=(self.access_key, self.secret_key))
             workload = rw.json()
@@ -36,33 +45,51 @@ class DeployRancher:
 
         rget = requests.get(self.rancher_deployment_path, auth=(self.access_key, self.secret_key))
         response = rget.json()
-        if 'status' in response and response['status'] == 404:
-            config = {
-                "containers": [{
-                    "imagePullPolicy": "Always",
-                    "image": self.docker_image,
-                    "name": self.service_name,
-                }],
-                "namespaceId": self.rancher_namespace,
-                "name": self.service_name
-            }
-
-            requests.post(self.rancher_workload_url_api, json=config, auth=(self.access_key, self.secret_key))
-        else:
-            response['containers'][0]['image'] = self.docker_image
-            result = requests.post(
-                self.rancher_deployment_path + '?action=redeploy', json=response,
-                auth=(self.access_key, self.secret_key)
-            )
-            print('completed with status code', result.status_code)
+        response['containers'][0]['image'] = self.docker_image
+        result = requests.post(
+            self.rancher_deployment_path + '?action=redeploy', json=response,
+            auth=(self.access_key, self.secret_key)
+        )
+        print('redeploy completed with status code', result.status_code)
         sys.exit(0)
+        # if 'status' in response and response['status'] == 404:
+        #     config = {
+        #         "containers": [{
+        #             "imagePullPolicy": "Always",
+        #             "image": self.docker_image,
+        #             "name": self.service_name,
+        #         }],
+        #         "namespaceId": self.rancher_namespace,
+        #         "name": self.service_name
+        #     }
+        #     requests.post(self.rancher_workload_url_api, json=config, auth=(self.access_key, self.secret_key))
+        # else:
+        #     response['containers'][0]['image'] = self.docker_image
+        #     result = requests.post(
+        #         self.rancher_deployment_path + '?action=redeploy', json=response,
+        #         auth=(self.access_key, self.secret_key)
+        #     )
+        #     print('completed with status code', result.status_code)
+        # sys.exit(0)
 
 
 def deploy_in_rancher(
-        rancher_access_key, rancher_secret_key, rancher_url_api, rancher_service_name, rancher_docker_image
+        rancher_access_key,
+        rancher_secret_key,
+        rancher_url_api,
+        rancher_cluster_id,
+        rancher_namespace_id,
+        rancher_service_name,
+        rancher_docker_image
 ):
     deployment = DeployRancher(
-        rancher_access_key, rancher_secret_key, rancher_url_api, rancher_service_name, rancher_docker_image
+        rancher_access_key,
+        rancher_secret_key,
+        rancher_url_api,
+        rancher_cluster_id,
+        rancher_namespace_id,
+        rancher_service_name,
+        rancher_docker_image
     )
     deployment.deploy()
 
@@ -71,16 +98,31 @@ if __name__ == '__main__':
     rancher_access_key = os.environ['RANCHER_ACCESS_KEY']
     rancher_secret_key = os.environ['RANCHER_SECRET_KEY']
     rancher_url_api = os.environ['RANCHER_URL_API']
+    rancher_cluster_id = os.environ['RANCHER_CLUSTER_ID']
+    rancher_namespace_id = os.environ['NAMESPACE_ID']
     rancher_service_name = os.environ['SERVICE_NAME']
     rancher_docker_image = os.environ['DOCKER_IMAGE']
     rancher_docker_image_latest = os.environ['DOCKER_IMAGE_LATEST']
     try:
-        deploy_in_rancher(rancher_access_key, rancher_secret_key, rancher_url_api,
-                          rancher_service_name, rancher_docker_image)
-
+        deploy_in_rancher(
+            rancher_access_key,
+            rancher_secret_key,
+            rancher_url_api,
+            rancher_cluster_id,
+            rancher_namespace_id,
+            rancher_service_name,
+            rancher_docker_image
+        )
         if rancher_docker_image_latest != None and rancher_docker_image_latest != "":
-            deploy_in_rancher(rancher_access_key, rancher_secret_key, rancher_url_api,
-                              rancher_service_name, rancher_docker_image_latest)
+            deploy_in_rancher(
+                rancher_access_key,
+                rancher_secret_key,
+                rancher_url_api,
+                rancher_cluster_id,
+                rancher_namespace_id,
+                rancher_service_name,
+                rancher_docker_image_latest
+            )
 
     except Exception as e:
         print(e)


### PR DESCRIPTION
When there was another cluster with similar workload naming, this action deployed first cluster workload it could find. Now it takes in count cluster id and target namespace so that right action is re deployed.

Disabled initial deployment because theres so many options to configure so that initial deployment should be done by hand instead.